### PR TITLE
Update documentation with correct keys

### DIFF
--- a/docs/guide/dashboard-widgets/ordered-list.md
+++ b/docs/guide/dashboard-widgets/ordered-list.md
@@ -21,12 +21,12 @@ function buildWidgetsData()
         "topTravelledShipTypes", [
             [
                 "label" => "model EF5978",
-                "link" => "/sharp/form/shiptype/12",
+                "url" => "/sharp/form/shiptype/12",
                 "count" => 89
             ],
             [
                 "label" => "model TT4448",
-                "link" => "/sharp/form/shiptype/24",
+                "url" => "/sharp/form/shiptype/24",
             ],
             [
                 "label" => "model EF5978",
@@ -41,6 +41,6 @@ function buildWidgetsData()
 ```
 
 Pass there the widget `key` and an array with the data as an array. Each array of the item should be an associative array. The key `label` is mandatory as it defines the ordered list item main content. You can also optionally define :
- - a link with key `link` associated with a valid url, the item then becomes clickable
+ - a link with key `url` associated with a valid url, the item then becomes clickable
  - a count with key `count` associated with a number, it will show a badge with given value
  

--- a/saturn/app/Sharp/CompanyDashboard.php
+++ b/saturn/app/Sharp/CompanyDashboard.php
@@ -129,12 +129,12 @@ class CompanyDashboard extends SharpDashboard
                 ],
                 [
                     "label" => "Adams",
-                    "url" => "https://sharp.test/shiptype/12",
+                    "url" => "/shiptype/12",
                 ],
                 [
                     "label" => "Quia",
                     "count" => 55,
-                    "url" => "https://sharp.test/shiptype/31",
+                    "url" => "/shiptype/31",
                 ],
             ]
         );


### PR DESCRIPTION
Ordered list data should have `url` keys instead of `link` keys for links